### PR TITLE
If server/port is missing trailing slash, add it without an OS dependency

### DIFF
--- a/tomcatWarDeployer.py
+++ b/tomcatWarDeployer.py
@@ -622,7 +622,8 @@ def validateManagerApplication(browser):
 def constructBaseUrl(host, url):
     host = host if host.startswith('http') else 'http://' + host
     uri = url[1:] if url.startswith('/') else url
-    return os.path.join(host, uri)
+    # return os.path.join(host, uri)
+    return host + "/" + uri
 
 def extractHostAddress(hostn, url):
     host = constructBaseUrl(hostn, url)

--- a/tomcatWarDeployer.py
+++ b/tomcatWarDeployer.py
@@ -621,9 +621,9 @@ def validateManagerApplication(browser):
 
 def constructBaseUrl(host, url):
     host = host if host.startswith('http') else 'http://' + host
+    host = host if host.endswith('/') else host + '/'
     uri = url[1:] if url.startswith('/') else url
-    # return os.path.join(host, uri)
-    return host + "/" + uri
+    return host + uri
 
 def extractHostAddress(hostn, url):
     host = constructBaseUrl(hostn, url)


### PR DESCRIPTION
If server/port is missing trailing slash, add it without an OS dependency