### PR TITLE
improvement: fixed inconsistent use of tabs and spaces in indentation

### DIFF
--- a/tomcatWarDeployer.py
+++ b/tomcatWarDeployer.py
@@ -1075,7 +1075,7 @@ def main():
             try:
                 browser, url = browseToManager(
                     args[0], opts.url, opts.user, opts.password)
-		if browser == 403 and url == 403:
+                if browser == 403 and url == 403:
                     browser = url = None
 
             except KeyboardInterrupt:


### PR DESCRIPTION
Fixes the following issue:
```bash
$ python tomcatWarDeployer.py
  File "/tmp/tomcatWarDeployer/tomcatWarDeployer.py", line 1078
    if browser == 403 and url == 403:
TabError: inconsistent use of tabs and spaces in indentation
```